### PR TITLE
fix(api): replace Microsoft.OpenApi.Models with Microsoft.OpenApi namespace

### DIFF
--- a/BelgiumVatChecker.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/BelgiumVatChecker.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 using BelgiumVatChecker.Core.Interfaces;
 using BelgiumVatChecker.Core.Services;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Polly;
 using Polly.Extensions.Http;
 


### PR DESCRIPTION
## What broke

CI has been failing since the .NET 10 migration with:

```
error CS0234: The type or namespace name 'Models' does not exist in the namespace 'Microsoft.OpenApi'
```

## Why it broke

`Swashbuckle.AspNetCore` v10 depends on **`Microsoft.OpenApi` v2.x**, which removed the `.Models` subnamespace as part of a major API cleanup. All model types (`OpenApiInfo`, `OpenApiContact`, `OpenApiLicense`, etc.) now live directly in the `Microsoft.OpenApi` namespace.

## What was fixed

Changed one using directive in `ServiceCollectionExtensions.cs`:

```diff
- using Microsoft.OpenApi.Models;
+ using Microsoft.OpenApi;
```

## Verification

Built locally with .NET SDK 10.0.103 — **Build succeeded, 0 errors, 0 warnings**.

---
*Auto-fix by Ritchie 🛠️ (CI Health Check — 2026-03-14)*