### PR TITLE
fix(tests): resolve Microsoft.Testing.Platform version mismatch

### DIFF
--- a/BelgiumVatChecker.Tests/BelgiumVatChecker.Tests.csproj
+++ b/BelgiumVatChecker.Tests/BelgiumVatChecker.Tests.csproj
@@ -21,7 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />


### PR DESCRIPTION
## Problem

CI has been failing since 2026-02-26 with a TypeLoadException at test runtime:

  'Could not load type IDataConsumer from Microsoft.Testing.Platform, Version=2.1.0.0'

## Root Cause

Version conflict:
- Microsoft.Testing.Extensions.CodeCoverage 18.5.1 ships transitive Microsoft.Testing.Platform.MSBuild 1.9.1
- xunit.v3 3.2.2 requires Microsoft.Testing.Platform 2.1.0

At runtime, the MSBuild extension (1.9.1) tries to register against MTP 2.1.0 and fails because IDataConsumer interface changed between versions.

## Fix

1. Bumped Microsoft.Testing.Extensions.CodeCoverage 18.5.1 -> 18.5.2
2. Added explicit Microsoft.Testing.Platform.MSBuild 2.1.0 to pin the transitive dep

Both packages now consistently reference MTP 2.1.0.

---
Auto-fix PR created by Ritchie (CTO auto-fix cron) on 2026-03-15