### PR TITLE
fix(api): update OpenApi packages and fix namespace for Microsoft.OpenApi v2 breaking change

### DIFF
--- a/BelgiumVatChecker.Api/BelgiumVatChecker.Api.csproj
+++ b/BelgiumVatChecker.Api/BelgiumVatChecker.Api.csproj
@@ -8,6 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.0" />
+    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>
 

--- a/BelgiumVatChecker.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/BelgiumVatChecker.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 using BelgiumVatChecker.Core.Interfaces;
 using BelgiumVatChecker.Core.Services;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Polly;
 using Polly.Extensions.Http;
 


### PR DESCRIPTION
## What broke

CI has been failing since March 3rd with:
```
error CS0234: The type or namespace name 'Models' does not exist in the namespace 'Microsoft.OpenApi'
```

## Why it broke

**Microsoft.OpenApi 2.x** (required by `Microsoft.AspNetCore.OpenApi 10.0.3`) removed the `Microsoft.OpenApi.Models` sub-namespace. Types like `OpenApiInfo`, `OpenApiContact`, and `OpenApiLicense` were moved to the root `Microsoft.OpenApi` namespace.

Additionally, `Polly` and `Polly.Extensions.Http` were only declared in `BelgiumVatChecker.Core` but used in `BelgiumVatChecker.Api`.

## What was fixed

1. **`BelgiumVatChecker.Api.csproj`**: Added missing package references:
   - `Microsoft.OpenApi 2.7.0` (explicit reference to resolve v2 namespace changes)
   - `Polly 8.6.6` (needed in Api, not just Core)
   - `Polly.Extensions.Http 3.0.0` (same)

2. **`ServiceCollectionExtensions.cs`**: Updated `using Microsoft.OpenApi.Models` → `using Microsoft.OpenApi`

## Verification

Build passes locally.

---
*🤖 Auto-fix by Ritchie (CTO) — morning CI health check 2026-03-16*