### PR TITLE
Fix OpenApi namespace and testing platform compatibility

### DIFF
--- a/BelgiumVatChecker.Api/BelgiumVatChecker.Api.csproj
+++ b/BelgiumVatChecker.Api/BelgiumVatChecker.Api.csproj
@@ -8,6 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.0" />
+    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>
 

--- a/BelgiumVatChecker.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/BelgiumVatChecker.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 using BelgiumVatChecker.Core.Interfaces;
 using BelgiumVatChecker.Core.Services;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Polly;
 using Polly.Extensions.Http;
 

--- a/BelgiumVatChecker.Tests/BelgiumVatChecker.Tests.csproj
+++ b/BelgiumVatChecker.Tests/BelgiumVatChecker.Tests.csproj
@@ -21,7 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />


### PR DESCRIPTION
## Summary
- **OpenApi namespace fix** (from PR #24): Change `Microsoft.OpenApi.Models` to `Microsoft.OpenApi` in `ServiceCollectionExtensions.cs` for Swashbuckle 10.x compatibility, and add explicit package references for `Microsoft.OpenApi 2.7.0`, `Polly 8.6.6`, and `Polly.Extensions.Http 3.0.0`
- **Testing platform fix** (from PR #23): Bump `Microsoft.Testing.Extensions.CodeCoverage` from `18.5.1` to `18.5.2` and pin `Microsoft.Testing.Platform.MSBuild 2.1.0` to fix test discovery issues

This PR combines the fixes from #23 and #24 into a single branch to resolve CI failures.

Supersedes #22, #23, and #24.

## Test plan
- [ ] Verify CI build passes (dotnet build)
- [ ] Verify CI tests pass (dotnet test)
- [ ] Confirm Swagger UI loads correctly